### PR TITLE
Batch transactions and other speedups

### DIFF
--- a/dynacred/src/Contact.ts
+++ b/dynacred/src/Contact.ts
@@ -17,8 +17,8 @@ import CredentialsInstance, { CredentialStruct } from "@dedis/cothority/personho
 import SpawnerInstance from "@dedis/cothority/personhood/spawner-instance";
 import { Data } from "src/lib/dynacred/Data";
 import { Public } from "src/lib/dynacred/KeyPair";
-import { parseQRCode } from "./Scan";
 import { SecureData } from "src/lib/dynacred/SecureData";
+import { parseQRCode } from "./Scan";
 
 // const ZXing = require("nativescript-zxing");
 // const QRGenerator = new ZXing();
@@ -288,12 +288,15 @@ export class Contact {
         }
     }
 
-    static async fromByzcoin(bc: ByzCoinRPC, credIID: InstanceID): Promise<Contact> {
+    static async fromByzcoin(bc: ByzCoinRPC, credIID: InstanceID, full: boolean = true): Promise<Contact> {
         const u = new Contact();
         u.credentialInstance = await CredentialsInstance.fromByzcoin(bc, credIID);
         u.credential = u.credentialInstance.credential.copy();
-        u.darcInstance = await DarcInstance.fromByzcoin(bc, u.credentialInstance.darcID);
-        u.coinInstance = await CoinInstance.fromByzcoin(bc, u.getCoinAddress());
+        if (full) {
+            u.darcInstance = await DarcInstance.fromByzcoin(bc, u.credentialInstance.darcID);
+            u.coinInstance = await CoinInstance.fromByzcoin(bc, u.getCoinAddress());
+        }
+        u.bc = bc;
         return u;
     }
 
@@ -423,10 +426,11 @@ export class Contact {
                 "with public key", this.seedPublic.toHex(), "and id", this.credentialIID.toString("hex"));
             this.credentialInstance = await CredentialsInstance.fromByzcoin(bc, this.credentialIID);
             this.credential = this.credentialInstance.credential.copy();
-            this.darcInstance = await DarcInstance.fromByzcoin(bc, this.credentialInstance.darcID);
-            this.coinInstance = await CoinInstance.fromByzcoin(bc, this.coinID);
-            this.spawnerInstance = await SpawnerInstance.fromByzcoin(bc, this.spawnerID);
-            Log.lvl2("done for", this.alias);
+            if (getContacts) {
+                this.darcInstance = await DarcInstance.fromByzcoin(bc, this.credentialInstance.darcID);
+                this.coinInstance = await CoinInstance.fromByzcoin(bc, this.coinID);
+                this.spawnerInstance = await SpawnerInstance.fromByzcoin(bc, this.spawnerID);
+            }
         } else {
             Log.lvl2("Updating user", this.alias);
             await this.credentialInstance.update();
@@ -438,6 +442,7 @@ export class Contact {
             await this.coinInstance.update();
         }
 
+        Log.lvl2("Updating credential version");
         for (let i = this.structVersion; i < Contact.structVersionLatest; i++) {
             switch (i) {
                 case 0:
@@ -446,10 +451,12 @@ export class Contact {
             }
         }
 
+        Log.lvl2("Updating contacts");
         if (getContacts && (!this.contactsCache || this.contactsCache.length === 0)) {
             await this.getContacts();
         }
 
+        Log.lvl2("done for", this.alias);
         return this;
     }
 
@@ -473,8 +480,9 @@ export class Contact {
             let hasFaulty: boolean = false;
             for (let c = 0; c < csBuf.length; c += 32) {
                 try {
-                    const cont = await Contact.fromByzcoin(this.bc, csBuf.slice(c, c + 32));
-                    await cont.updateOrConnect(this.bc, false);
+                    const d = new Date();
+                    const cont = await Contact.fromByzcoin(this.bc, csBuf.slice(c, c + 32), false);
+                    Log.lvl2(`Got contact ${cont.alias} in:`, new Date().getTime() - d.getTime());
                     this.contactsCache.push(cont);
                 } catch (e) {
                     Log.error("couldn't get contact - deleting");

--- a/webserver/src/app/admin/contacts/contacts.component.ts
+++ b/webserver/src/app/admin/contacts/contacts.component.ts
@@ -133,6 +133,7 @@ export class ContactsComponent implements OnInit {
                 const coins = Long.fromString(result);
                 if (coins.greaterThan(0)) {
                     await showSnack(this.snackBar, "Transferring coins", async () => {
+                        await c.updateOrConnect(gData.bc);
                         await gData.coinInstance.transfer(coins, c.coinInstance.id, [gData.keyIdentitySigner]);
                     });
                     await this.bcvs.updateBlocks();
@@ -151,6 +152,7 @@ export class ContactsComponent implements OnInit {
 
     async calypsoSearch(c: Contact) {
         await showSnack(this.snackBar, "Searching new secure data for " + c.alias.toLocaleUpperCase(), async () => {
+            await c.updateOrConnect(gData.bc);
             const sds = await gData.contact.calypso.read(c);
             await gData.save();
             this.updateCalypso();

--- a/webserver/src/app/c4dt/c4dt.component.html
+++ b/webserver/src/app/c4dt/c4dt.component.html
@@ -8,21 +8,21 @@
             Welcome
         </a>
         <a mat-tab-link routerLink="/c4dt/profile"
-           routerLinkActive #rla1="routerLinkActive" [active]="rla1.isActive">
+           routerLinkActive #rla2="routerLinkActive" [active]="rla2.isActive">
             Profile
         </a>
         <a *ngIf="isPartner"
            mat-tab-link routerLink="/c4dt/partner"
-           routerLinkActive #rla2="routerLinkActive" [active]="rla2.isActive">
+           routerLinkActive #rla3="routerLinkActive" [active]="rla3.isActive">
             Partner
         </a>
         <a *ngIf="showDevices"
            mat-tab-link routerLink="/c4dt/devices"
-           routerLinkActive #rla4="routerLinkActive" [active]="rla4.isActive">
+           routerLinkActive #rla5="routerLinkActive" [active]="rla5.isActive">
             Devices
         </a>
         <a mat-tab-link routerLink="/c4dt/status"
-           routerLinkActive #rla5="routerLinkActive" [active]="rla5.isActive">
+           routerLinkActive #rla6="routerLinkActive" [active]="rla6.isActive">
             Status
         </a>
     </nav>

--- a/webserver/src/app/c4dt/profile/profile.component.html
+++ b/webserver/src/app/c4dt/profile/profile.component.html
@@ -1,4 +1,4 @@
-<h1>Welcome {{gData.contact.alias | titlecase}}</h1>
+<h2>Profile</h2>
 <form [formGroup]="contactForm" class="formwidth" (ngSubmit)="updateContact()">
 
     <mat-form-field class="width100">

--- a/webserver/src/app/c4dt/profile/profile.component.ts
+++ b/webserver/src/app/c4dt/profile/profile.component.ts
@@ -6,7 +6,7 @@ import { showDialogInfo, showSnack } from "../../../lib/Ui";
 import { BcviewerService } from "../../bcviewer/bcviewer.component";
 
 @Component({
-    selector: "app-user",
+    selector: "app-profile",
     styleUrls: ["./profile.component.css"],
     templateUrl: "./profile.component.html",
 })


### PR DESCRIPTION
This PR batches the transactions necessary to create an user, which makes the user
creation much faster. It puts all instructions in one ClientTransaction and then
sends this to the conodes.

It also removes a lot of double-loading for the contacts. On startup, it will only
load the credentialInstance of each contact, the rest has to be loaded when
needed.

Closes #24 
Closes #20 