### PR TITLE
webserver: karma firefox and single run

### DIFF
--- a/webserver/package-lock.json
+++ b/webserver/package-lock.json
@@ -5432,6 +5432,11 @@
         "minimatch": "^3.0.4"
       }
     },
+    "karma-firefox-launcher": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/karma-firefox-launcher/-/karma-firefox-launcher-1.1.0.tgz",
+      "integrity": "sha512-LbZ5/XlIXLeQ3cqnCbYLn+rOVhuMIK9aZwlP6eOLGzWdo1UVp7t6CN3DP4SafiRLjexKwHeKHDm0c38Mtd3VxA=="
+    },
     "karma-jasmine": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-2.0.1.tgz",

--- a/webserver/package.json
+++ b/webserver/package.json
@@ -31,6 +31,7 @@
     "crypto-browserify": "^3.12.0",
     "dexie": "^2.0.4",
     "hammerjs": "^2.0.8",
+    "karma-firefox-launcher": "^1.1.0",
     "keccak": "^2.0.0",
     "rxjs": "~6.3.3",
     "tslib": "^1.10.0",

--- a/webserver/src/karma.conf.js
+++ b/webserver/src/karma.conf.js
@@ -8,6 +8,7 @@ module.exports = function(config) {
     plugins: [
       require("karma-jasmine"),
       require("karma-chrome-launcher"),
+      require("karma-firefox-launcher"),
       // require('karma-jasmine-html-reporter'),
       require("karma-coverage-istanbul-reporter"),
       require("@angular-devkit/build-angular/plugins/karma"),

--- a/webserver/src/karma.conf.js
+++ b/webserver/src/karma.conf.js
@@ -29,7 +29,7 @@ module.exports = function(config) {
     autoWatch: true,
     browsers: ["ChromeHeadless"],
     // browsers: ['Chrome'],
-    singleRun: false,
+    singleRun: true,
     restartOnFileChange: true,
   });
 };


### PR DESCRIPTION
Start of c4dt/TODO#28 chain.

* add Firefox launcher (using it on my side); we can use phantom-js instead, which I find more fit to a testing env, but to avoid breaking with Chrome-only users, for now, simply adding it
* by default now, karma will `singleRun`, so testing finishes (classique behavior of tests), to have the same behavior as before, one would `npm run test -- --watch` (or directly `ng test --watch`)