### PR TITLE
test build --prod

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ jobs:
         - npm run lint
         - d=node_modules/@c4dt/dynacred && rm -r $d && ln -s ../../../dynacred/dist $d
       script:
-        - npm run build
+        - npm run build --prod
         - npm run test --no-watch
 
     - stage: deploy


### PR DESCRIPTION
For unknown reasons, 'ng build --prod' does a more thorough test with regard
to private/public attributes than 'ng build' only.