### PR TITLE
correctly show darc.base_id and switch to es6

### DIFF
--- a/webapp/Makefile
+++ b/webapp/Makefile
@@ -63,4 +63,4 @@ src: cothority_src
 npm: dynacred_npm
 
 serve:
-	ng serve --disable-host-check
+	ng serve --disable-host-check --aot

--- a/webapp/src/app/admin/contacts/show-darcinstance.html
+++ b/webapp/src/app/admin/contacts/show-darcinstance.html
@@ -1,7 +1,7 @@
 <div class="mat-body">
     <h2>Details of "{{ data.inst.darc.description.toString() | titlecase }}"</h2>
     <p>
-    ID: {{ data.inst.darc.id.toString("hex") }}
+    ID: {{ data.inst.id.toString("hex") }}
     <p>
     Version: {{ data.inst.darc.version }}
     <p>

--- a/webapp/src/app/api/v0/cas/login/login.component.ts
+++ b/webapp/src/app/api/v0/cas/login/login.component.ts
@@ -16,7 +16,7 @@ import { UserData } from "../../../../user-data.service";
 })
 export class LoginComponent implements OnInit {
     static readonly casLoginDarc =
-        Buffer.from("ed6175116686d3326d8dabbfe9a73c8d03cd0ceb86d000e42f274d958eb2a398", "hex");
+        Buffer.from("b7240d7e4bcc33b4a2af5d2110c512f3118478b964f2b4be9f99b27853702489", "hex");
     server: string;
     authorized = false;
     private service: string;

--- a/webapp/tsconfig.json
+++ b/webapp/tsconfig.json
@@ -12,7 +12,7 @@
     "importHelpers": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,
-    "target": "es5",
+    "target": "es6",
     "typeRoots": [
       "node_modules/@types"
     ],


### PR DESCRIPTION
Darc.base_id is only the same as darc.id for version == 0

Switch to es6, so `user-data` can `super` on `Data`

Update darc used for matrix login