### PR TITLE
Fix packaging for dynacred

### DIFF
--- a/dynacred/package.json
+++ b/dynacred/package.json
@@ -2,11 +2,8 @@
   "name": "@c4dt/dynacred",
   "version": "0.0.5",
   "description": "The library used by the omniledger-ui and the personhood.online app",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "files": [
-    "dist/"
-  ],
+  "main": "index.js",
+  "types": "index.d.ts",
   "browser": "bundle.min.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
As it is, when I `npm i @c4dt/dynacred`, I get the following result:
```
$ tree node_modules/@c4dt/dynacred/
node_modules/@c4dt/dynacred/
├── bundle.min.js
├── package.json
└── README.md

0 directories, 3 files
```
This commit (actually a revert on `package.json`) appears to fix it for me. It seems this was changed recently, am I missing something?