### PR TITLE
remove view- and groups-choice from c4dt_partner createUser

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -24,7 +24,7 @@
     "@angular/platform-browser": "^7.2.15",
     "@angular/platform-browser-dynamic": "^7.2.15",
     "@angular/router": "^7.2.15",
-    "@c4dt/cothority": "^3.1.15",
+    "@dedis/cothority": "^3.1.3",
     "@c4dt/dynacred": "dev",
     "@dedis/kyber": "^3.0.7",
     "core-js": "^2.6.9",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -24,7 +24,7 @@
     "@angular/platform-browser": "^7.2.15",
     "@angular/platform-browser-dynamic": "^7.2.15",
     "@angular/router": "^7.2.15",
-    "@dedis/cothority": "^3.1.3",
+    "@c4dt/cothority": "^3.1.15",
     "@c4dt/dynacred": "dev",
     "@dedis/kyber": "^3.0.7",
     "core-js": "^2.6.9",

--- a/webapp/src/app/admin/contacts/contacts.component.ts
+++ b/webapp/src/app/admin/contacts/contacts.component.ts
@@ -38,9 +38,9 @@ export class ContactsComponent implements OnInit {
 
     constructor(
         protected dialog: MatDialog,
-        protected snackBar: MatSnackBar,
-        protected bcvs: BcviewerService,
-        protected location: Location,
+        private snackBar: MatSnackBar,
+        private bcvs: BcviewerService,
+        private location: Location,
         public uData: UserData,
     ) {
         this.calypsoOtherKeys = new Map();
@@ -67,15 +67,15 @@ export class ContactsComponent implements OnInit {
      * If any of the view or groups parameter is the non-default, it will not be asked
      * by the dialog.
      *
-     * @param view - must be either "" or one of Data.views
-     * @param groups - must be either [] or one of the user's available groups
+     * @param view - must be either undefined or one of Data.views
+     * @param groups - must be either undefined or one of the user's available groups
      */
-    async createContact(view: string = "", groups: string[] = []) {
+    async createContact(view?: string, groups?: string[]) {
         const groupsInstAvail = await this.uData.contact.getGroups();
         const groupsAvail = groupsInstAvail.map((g) => g.darc.description.toString());
         const creds: IUserCred = {alias: "", email: "", view, groups, groupsAvail};
         // Search if the proposed groups are really available to the user
-        if (groups.find((group) => groupsAvail.find((g) => g === group) === undefined)) {
+        if (groups && groups.find((group) => groupsAvail.find((g) => g === group) === undefined)) {
             return Promise.reject("unknown group");
         }
         const ac = this.dialog.open(UserCredComponent, {
@@ -405,8 +405,8 @@ export class UserCredComponent {
     constructor(
         public dialogRef: MatDialogRef<TransferCoinComponent>,
         @Inject(MAT_DIALOG_DATA) public data: IUserCred) {
-        this.showGroups = data.groups.length === 0;
-        this.showViews = data.view === "";
+        this.showGroups = data.groups === undefined;
+        this.showViews = data.view === undefined;
         if (this.showViews) {
             data.view = Data.views[0];
         }

--- a/webapp/src/app/admin/contacts/user-cred.html
+++ b/webapp/src/app/admin/contacts/user-cred.html
@@ -7,7 +7,7 @@
         <mat-form-field class="width100">
             <input matInput [(ngModel)]="data.email" placeholder="Email for new user">
         </mat-form-field>
-        <mat-form-field class="width100">
+        <mat-form-field class="width100" *ngIf="showViews">
             <mat-label>Default view for user</mat-label>
             <mat-select [(value)]="data.view">
                 <mat-option *ngFor="let view of views" [value]="view">
@@ -15,10 +15,10 @@
                 </mat-option>
             </mat-select>
         </mat-form-field>
-        <mat-form-field>
+        <mat-form-field *ngIf="showGroups">
             <mat-label>Groups for user</mat-label>
             <mat-select [(value)]="data.groups" multiple>
-                <mat-option *ngFor="let group of groupsAvail" [value]="group">{{group}}</mat-option>
+                <mat-option *ngFor="let group of data.groupsAvail" [value]="group">{{group}}</mat-option>
             </mat-select>
         </mat-form-field>
     </p>

--- a/webapp/src/app/app.component.ts
+++ b/webapp/src/app/app.component.ts
@@ -4,8 +4,6 @@ import { Router } from "@angular/router";
 
 import Log from "@dedis/cothority/log";
 
-import { Defaults } from "@c4dt/dynacred/Defaults";
-
 import { BcviewerService } from "./bcviewer/bcviewer.component";
 import { UserData } from "./user-data.service";
 

--- a/webapp/src/app/c4dt/partner/partner.component.html
+++ b/webapp/src/app/c4dt/partner/partner.component.html
@@ -6,6 +6,6 @@
     </li>
 </ul>
 <div>
-    <button mat-stroked-button color="primary" (click)="createContact('c4dt_user')">Create C4DT User</button>
+    <button mat-stroked-button color="primary" (click)="createSimpleContact()">New User</button>
     <button mat-stroked-button color="primary" (click)="addContact()">Add Contact</button>
 </div>

--- a/webapp/src/app/c4dt/partner/partner.component.ts
+++ b/webapp/src/app/c4dt/partner/partner.component.ts
@@ -23,10 +23,6 @@ export class PartnerComponent extends ContactsComponent {
         super(dialog, snackBar, bcvs, location, uData);
     }
 
-    async ngOnInit() {
-        await super.ngOnInit();
-    }
-
     async createSimpleContact() {
         const groups = await this.uData.contact.getGroups();
         if (groups.length === 0) {

--- a/webapp/src/app/c4dt/partner/partner.component.ts
+++ b/webapp/src/app/c4dt/partner/partner.component.ts
@@ -1,6 +1,8 @@
 import { Location } from "@angular/common";
 import { Component } from "@angular/core";
 import { MatDialog, MatSnackBar } from "@angular/material";
+import Log from "@dedis/cothority/log";
+import { showDialogInfo } from "../../../lib/Ui";
 import { ContactsComponent } from "../../admin/contacts/contacts.component";
 import { BcviewerService } from "../../bcviewer/bcviewer.component";
 import { UserData } from "../../user-data.service";
@@ -22,6 +24,15 @@ export class PartnerComponent extends ContactsComponent {
     }
 
     async ngOnInit() {
-        super.ngOnInit();
+        await super.ngOnInit();
+    }
+
+    async createSimpleContact() {
+        const groups = await this.uData.contact.getGroups();
+        if (groups.length === 0) {
+            return showDialogInfo(this.dialog, "No Group Found", "There are no groups tied to your account.\n" +
+                "Wait some seconds and try again.", "Understood");
+        }
+        await super.createContact("c4dt_user", [groups[0].darc.description.toString()]);
     }
 }

--- a/webapp/src/app/c4dt/partner/partner.component.ts
+++ b/webapp/src/app/c4dt/partner/partner.component.ts
@@ -1,7 +1,6 @@
 import { Location } from "@angular/common";
 import { Component } from "@angular/core";
 import { MatDialog, MatSnackBar } from "@angular/material";
-import Log from "@dedis/cothority/log";
 import { showDialogInfo } from "../../../lib/Ui";
 import { ContactsComponent } from "../../admin/contacts/contacts.component";
 import { BcviewerService } from "../../bcviewer/bcviewer.component";


### PR DESCRIPTION
The C4DT partners should not be able to chose the view and the groups from the user,
but this should be created automatically for them. If they _do_ want to influence
this, they have to use the /admin-interface.