### PR TITLE
Update Makefiles and helpers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,9 @@ jobs:
       script:
         - cd conode
         - export GO111MODULE=on
-        - make docker_run &
+        - make docker_run_travis &
         - make docker_wait
+        - make utils
         - build/bcadmin latest --bc bc*cfg
     - name: dynacred
       language: node_js

--- a/Makefile
+++ b/Makefile
@@ -7,16 +7,17 @@ swap:
 	@if [ ${COT} = ${to} ]; then \
 		echo "Already pointing to ${to}/cothority"; exit 1; \
 	 fi
-	@for d in dynacred webapp; do \
-	  cd $$d; \
+	@for d in dynacred webapp mobile; do \
+	  cd $$d && \
 	  for p in cothority kyber; do \
-		perl -pi -e "s:${from}/$$p:${to}/$$p:" $$( find app spec src -name "*.ts" ); \
-		npm remove @${from}/$$p; \
+		perl -pi -e "s:${from}/$$p:${to}/$$p:" Makefile $$( find app spec src -name "*.ts" ) && \
+		npm remove @${from}/$$p && \
 		npm i --save @${to}/$$p; \
-	  done; \
-	  npm run lint:fix; \
+	  done && \
+	  npm audit fix && \
+	  npm run lint:fix && \
 	  cd ..; \
-	done
+	done && \
 	perl -pi -e "s/^COT := .*/COT := ${to}/" ./Makefile
 
 cothority:

--- a/conode/Makefile
+++ b/conode/Makefile
@@ -39,17 +39,16 @@ docker: build/Dockerfile cothority-pull
 	docker build -t $(IMAGE_NAME):$(TAG) -f build/Dockerfile build
 	docker tag $(IMAGE_NAME):$(TAG) $(IMAGE_NAME):dev
 
-update_assets:
-	docker rm -f $(CONTAINER) || echo nothing to stop
-	echo "ByzCoinID = \"$$( grep ByzCoinID variables.txt | sed -e 's/.* //' )\"" > $(WEBAPP_ASSET)
-	echo >> $(WEBAPP_ASSET)
-	cat build/conodes/public.toml >> $(WEBAPP_ASSET)
+$(WEPAPP_ASSET): variables.txt build/conodes/public.toml
+	 echo "ByzCoinID = \"$$( grep ByzCoinID $< | sed -e 's/.* //' )\"" > $@
+	 echo >> $@
+	 cat $(lastword $^) >> $@
 
 docker_run: docker update_assets
 	docker run --rm -ti -p 7770-7777:7770-7777 --name $(CONTAINER) $(IMAGE_NAME):dev
 
 docker_run_travis: docker
-	docker run --rm -t -p 7770-7777:7770-7777 --name $(CONTAINER) $(IMAGE_NAME):dev
+	docker run --rm -p 7770-7777:7770-7777 --name $(CONTAINER) $(IMAGE_NAME):dev
 
 docker_wait:
 	@for port in $$( seq 7771 2 7777 ); do \

--- a/conode/Makefile
+++ b/conode/Makefile
@@ -5,10 +5,11 @@ WEBAPP_ASSET := ../webapp/src/assets/config.toml
 
 all: docker
 
-.PHONY: conode
+.PHONY: cothority-pull conode newdb docker docker_run docker_wait docker_stop docker_start docker_clean clean
 
-conode:
-	make -C .. cothority-pull
+.DEFAULT_GOAL := docker_run
+
+utils: cothority-pull
 	@echo "Compiling binaries"; \
 	go build -o build/conode; \
 	cd ../cothority && \
@@ -16,7 +17,10 @@ conode:
 		go build -o ../conode/build/csadmin ./calypso/csadmin && \
 		go build -o ../conode/build/phapp ./personhood/phapp
 
-newdb: conode
+cothority-pull:
+	make -C .. cothority-pull
+
+newdb: utils
 	rm -f build/conodes/*db;
 	@echo "Starting nodes"; \
 	( cd build; COTHORITY_ALLOW_INSECURE_ADMIN=true ./run_nodes.sh -v 2 -t -n 4 -s -d conodes > /dev/null ) & \
@@ -29,20 +33,22 @@ newdb: conode
 	echo; echo "Shutting down conodes"; pkill -x conode; rm -f conodes/running
 
 # Use this target to build from local source
-docker: build/Dockerfile conode
+docker: build/Dockerfile cothority-pull
 	@export GO111MODULE=on GOOS=linux GOARCH=amd64; \
-	go build -o build/conode; \
-	cd ../cothority && \
-		go build -o ../conode/build/bcadmin ./byzcoin/bcadmin && \
-		go build -o ../conode/build/csadmin ./calypso/csadmin
+	go build -o build/conode
 	docker build -t $(IMAGE_NAME):$(TAG) -f build/Dockerfile build
 	docker tag $(IMAGE_NAME):$(TAG) $(IMAGE_NAME):dev
 
-docker_run: docker
+update_assets:
 	docker rm -f $(CONTAINER) || echo nothing to stop
 	echo "ByzCoinID = \"$$( grep ByzCoinID variables.txt | sed -e 's/.* //' )\"" > $(WEBAPP_ASSET)
 	echo >> $(WEBAPP_ASSET)
 	cat build/conodes/public.toml >> $(WEBAPP_ASSET)
+
+docker_run: docker update_assets
+	docker run --rm -ti -p 7770-7777:7770-7777 --name $(CONTAINER) $(IMAGE_NAME):dev
+
+docker_run_travis: docker
 	docker run --rm -t -p 7770-7777:7770-7777 --name $(CONTAINER) $(IMAGE_NAME):dev
 
 docker_wait:

--- a/conode/build/Dockerfile
+++ b/conode/build/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:stretch-slim
 WORKDIR /root/
 COPY conodes ./conodes
-COPY conode bcadmin csadmin run_nodes.sh ./
+COPY conode run_nodes.sh ./
 
 EXPOSE 7770 7771 7772 7773 7774 7775 7776 7777
 

--- a/conode/go.mod
+++ b/conode/go.mod
@@ -12,4 +12,6 @@ require (
 	google.golang.org/appengine v1.6.5 // indirect
 )
 
+replace go.dedis.ch/cothority/v3 => ../cothority
+
 go 1.13

--- a/dynacred/Makefile
+++ b/dynacred/Makefile
@@ -1,11 +1,14 @@
+deps:
+    npm ci
+
 none:
 	@echo "Not breaking if you don't tell me what to do"
 
-use_src:
+src:
 	make -C .. cothority-pull
 	ln -s ../../../cothority/external/js/cothority/src src/lib/cothority
 	ln -s ../../../cothority/external/js/kyber/src src/lib/kyber
 
-use_npm:
+npm:
 	rm -f src/lib/{cothority,kyber}
 

--- a/mobile/Makefile
+++ b/mobile/Makefile
@@ -19,6 +19,11 @@ clean: gradle-simul
 	rm -rf node_modules platforms hooks
 
 npm-install: clean
+	# if dynacred is installed from the parent's directory with `npm i ../dynacred`,
+	# npm will install all dependencies, including @c4dt/cothority, and this will conflict with
+	# the @c4dt/cothority in mobile, which will lead to structures form the different cothorities not
+	# being recognized as the same, e.g., `r instanceof Roster` will not work over the two packages...
+	[ -d dynacred ] || ln -s $$(pwd)/../dynacred .
 	npm ci
 	find app -name "*js" -delete
 
@@ -26,7 +31,6 @@ apply-patches: npm-install
 	patch -p0 < nodeify_temporary_patch.patch
 	cp nodeify_noxml.js node_modules/nativescript-nodeify/nodeify.js
 	rm -rf node_modules/public-encrypt/test/
-	[ ! -d app/lib/dynacred ] || npm link ../dynacred
 
 android-dev: apply-patches
 	tns prepare android
@@ -164,7 +168,7 @@ dynacred_npm: cothority_npm
 		( echo "Moving changes to dynacred"; cp -a app/lib/dynacred/* ../dynacred/src ); \
 	rm -rf app/lib/dynacred && \
 	find app/ -name "*.ts" | xargs perl -pi -e "s:~/lib/dynacred:\@c4dt/dynacred:" && \
-	cd ../dynacred; npm run lint:fix && \
+	( cd ../dynacred; npm run lint:fix ) && \
 	npm i -s @c4dt/dynacred
 
 src: kyber_src

--- a/mobile/nodeify.sh
+++ b/mobile/nodeify.sh
@@ -3,13 +3,11 @@ FILE="$1"
 if [[ "$2" ]]; then
     FILE="$2"
     echo "Unnodifying $FILE"
-    perl -pi -e 's/from "crypto-browserify"/from "crypto"/' "$FILE"
     if grep -q "nativescript-nodeify" "$FILE"; then
         sed -i '' '1,3d' "$FILE"
     fi
 else
     echo "Nodifying $FILE"
-    perl -pi -e 's/from "crypto"/from "crypto-browserify"/' "$FILE"
     if grep -rilq '^import.*"crypto' $FILE; then
         echo -e '// tslint:disable-next-line\nrequire("nativescript-nodeify");'\n | cat - "$FILE" > "$FILE.tmp"
     fi

--- a/webapp/Makefile
+++ b/webapp/Makefile
@@ -1,14 +1,19 @@
-none:
-	@echo "Not breaking if you don't tell me what to do"
+.DEFAULT_GOAL := build_serve
 
-use_src:
+deps:
+	npm ci
+	npm link ../dynacred
+
+src:
 	make -C ../dynacred use_src
-	ln -s ../../../cothority/external/js/cothority/src src/lib/cothority
-	ln -s ../../../cothority/external/js/kyber/src src/lib/kyber
+	ln -s $$(pwd)/../cothority/external/js/cothority/src src/lib/cothority
+	ln -s $$(pwd)/../cothority/external/js/kyber/src src/lib/kyber
 
-use_npm:
+npm:
 	make -C ../dynacred use_npm
 	rm -f src/lib/{cothority,kyber}
 
 serve:
 	ng serve --disable-host-check --aot
+
+build_serve: deps serve


### PR DESCRIPTION
This PR makes sure that all Makefiles can be used as they are supposed to be,
in order to:
- dynacred, mobile: build or prepare the directory
- conode, webapp: run the app in the directory
- dynacred, mobile, webapp: switch between libraries as source or as npms