### PR TITLE
Fixing make src

### DIFF
--- a/dynacred/Makefile
+++ b/dynacred/Makefile
@@ -4,10 +4,20 @@ deps:
 none:
 	@echo "Not breaking if you don't tell me what to do"
 
-src:
+cothority-pull:
 	make -C .. cothority-pull
-	ln -s ../../../cothority/external/js/cothority/src src/lib/cothority
-	ln -s ../../../cothority/external/js/kyber/src src/lib/kyber
+
+.PHONY: src
+src: cothority-pull src/lib/cothority src/lib/kyber
+
+src/lib:
+	mkdir -p src/lib
+
+src/lib/cothority: src/lib
+	ln -s $$(pwd)/../cothority/external/js/cothority/src src/lib/cothority
+
+src/lib/kyber: src/lib
+	ln -s $$(pwd)/../cothority/external/js/kyber/src src/lib/kyber
 
 npm:
 	rm -f src/lib/{cothority,kyber}

--- a/webapp/Makefile
+++ b/webapp/Makefile
@@ -6,13 +6,23 @@
 deps: ../dynacred/build/index.js
 	npm ci
 
-src:
-	make -C ../dynacred use_src
+dynacred-src:
+	make -C ../dynacred src
+
+.PHONY: src
+src: dynacred-src src/lib/cothority src/lib/kyber
+
+src/lib:
+	mkdir -p src/lib
+
+src/lib/cothority: src/lib
 	ln -s $$(pwd)/../cothority/external/js/cothority/src src/lib/cothority
+
+src/lib/kyber: src/lib
 	ln -s $$(pwd)/../cothority/external/js/kyber/src src/lib/kyber
 
 npm:
-	make -C ../dynacred use_npm
+	make -C ../dynacred npm
 	rm -f src/lib/{cothority,kyber}
 
 serve:

--- a/webapp/tsconfig.json
+++ b/webapp/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../tsconfig.common.json",
   "compileOnSave": false,
   "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
     "baseUrl": "./",
     "downlevelIteration": true,
     "outDir": "./dist/out-tsc",


### PR DESCRIPTION
When wanting to work directly on the source of cothority and kyber,
'make src' copies the latest source of these libraries directly into
the webapp- and dynacred-sources.