### PR TITLE
Real fix for endless loop and long block loading …

### DIFF
--- a/dynacred/package-lock.json
+++ b/dynacred/package-lock.json
@@ -331,9 +331,9 @@
       "integrity": "sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q=="
     },
     "@types/node": {
-      "version": "12.12.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.14.tgz",
-      "integrity": "sha512-u/SJDyXwuihpwjXy7hOOghagLEV1KdAST6syfnOk6QZAMzZuWZqXy5aYYZbh8Jdpd4escVFP0MvftHNDb9pruA=="
+      "version": "12.12.24",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.24.tgz",
+      "integrity": "sha512-1Ciqv9pqwVtW6FsIUKSZNB82E5Cu1I2bBTj1xuIHXLe/1zYLl3956Nbhg2MzSYHVfl9/rmanjbQIb7LibfCnug=="
     },
     "@types/sprintf-js": {
       "version": "1.1.2",

--- a/webapp/.gitignore
+++ b/webapp/.gitignore
@@ -46,3 +46,5 @@ testem.log
 Thumbs.db
 
 cothority/
+src/lib/cothority
+src/lib/kyber

--- a/webapp/src/app/app.component.ts
+++ b/webapp/src/app/app.component.ts
@@ -68,16 +68,15 @@ export class AppComponent implements OnInit {
                     this.uData.setValues({});
                     await this.uData.save();
                     await showDialogOKC(this.dialog, "Device revoked", "Sorry, but this device has been revoked." +
-                    " If you want to use it again, you'll have to re-activate it.");
+                        " If you want to use it again, you'll have to re-activate it.");
                     return this.newUser();
                 }
                 this.logAppend("Done", 100);
                 this.loading = false;
-                if (!window.location.pathname.match(/\/cas\//)) {
-                    Log.lvl2("Starting to update blocks for viewer");
-                    this.bcviewer = true;
-                    this.bcs.updateBlocks();
-                }
+                Log.lvl2("Starting to update blocks for viewer");
+                this.bcs.updateBlocks();
+                this.bcviewer = true;
+
             } catch (e) {
                 // Data was here, but loading failed afterward - might be a network failure.
                 const fileDialog = this.dialog.open(RetryLoadComponent, {

--- a/webapp/src/app/user-data.service.ts
+++ b/webapp/src/app/user-data.service.ts
@@ -26,7 +26,7 @@ export class UserData extends Data {
     private readonly dbLatest = "latest_skipblock";
     // This is the hardcoded block at 0x6000, supposed to have higher forward-links. Once 0x8000 is created,
     // this will be updated.
-    private readonly id0x6000 = "3781100c76ab3e6243da881036372387f8237c59cedd27fa0f556f71dc2dff48";
+    private readonly id0x6000 = Buffer.from("3781100c76ab3e6243da881036372387f8237c59cedd27fa0f556f71dc2dff48", "hex");
 
     constructor() {
         super(undefined); // poison
@@ -58,7 +58,7 @@ export class UserData extends Data {
         } else {
             const sc = new SkipchainRPC(this.conn);
             try {
-                latest = await sc.getSkipBlock(Buffer.from(this.id0x6000, "hex"));
+                latest = await sc.getSkipBlock(this.id0x6000);
                 Log.lvl2("Got skipblock 0x6000");
             } catch (e) {
                 Log.lvl2("couldn't get block 0x6000", e);

--- a/webapp/src/app/user-data.service.ts
+++ b/webapp/src/app/user-data.service.ts
@@ -23,7 +23,7 @@ export class UserData extends Data {
     bc: ByzCoinRPC;
     config: Config;
     conn: IConnection;
-    private readonly dbLatest = "latest_skipblock";
+    private readonly storageKeyLatest = "latest_skipblock";
     // This is the hardcoded block at 0x6000, supposed to have higher forward-links. Once 0x8000 is created,
     // this will be updated.
     private readonly id0x6000 = Buffer.from("3781100c76ab3e6243da881036372387f8237c59cedd27fa0f556f71dc2dff48", "hex");
@@ -51,7 +51,7 @@ export class UserData extends Data {
         this.conn.setParallel(1);
         logger("Fetching latest block", 70);
         let latest: SkipBlock;
-        const latestBuf = await this.storage.get(this.dbLatest);
+        const latestBuf = await this.storage.get(this.storageKeyLatest);
         if (latestBuf !== undefined) {
             latest = SkipBlock.decode(Buffer.from(latestBuf, "hex"));
             Log.lvl2("Loaded latest block from db:", latest.index);
@@ -66,7 +66,7 @@ export class UserData extends Data {
         }
         this.bc = await ByzCoinRPC.fromByzcoin(this.conn, this.config.byzCoinID, 3, 1000, latest);
         Log.lvl2("storing latest block in db:", this.bc.latest.index);
-        this.storage.set(this.dbLatest, Buffer.from(SkipBlock.encode(this.bc.latest).finish()).toString("hex"));
+        this.storage.set(this.storageKeyLatest, Buffer.from(SkipBlock.encode(this.bc.latest).finish()).toString("hex"));
         logger("Done connecting", 100);
     }
 

--- a/webapp/src/app/user-data.service.ts
+++ b/webapp/src/app/user-data.service.ts
@@ -6,6 +6,7 @@ import { ByzCoinRPC } from "@c4dt/cothority/byzcoin";
 import Log from "@c4dt/cothority/log";
 
 import { IConnection, RosterWSConnection } from "@c4dt/cothority/network/connection";
+import { SkipBlock, SkipchainRPC } from "@c4dt/cothority/skipchain";
 import { StatusRequest, StatusResponse } from "@c4dt/cothority/status/proto";
 import StatusRPC from "@c4dt/cothority/status/status-rpc";
 import { Config, Data, StorageDB } from "@c4dt/dynacred";
@@ -22,6 +23,10 @@ export class UserData extends Data {
     bc: ByzCoinRPC;
     config: Config;
     conn: IConnection;
+    private readonly dbLatest = "latest_skipblock";
+    // This is the hardcoded block at 0x6000, supposed to have higher forward-links. Once 0x8000 is created,
+    // this will be updated.
+    private readonly id0x6000 = "3781100c76ab3e6243da881036372387f8237c59cedd27fa0f556f71dc2dff48";
 
     constructor() {
         super(undefined); // poison
@@ -45,7 +50,23 @@ export class UserData extends Data {
         }
         this.conn.setParallel(1);
         logger("Fetching latest block", 70);
-        this.bc = await ByzCoinRPC.fromByzcoin(this.conn, this.config.byzCoinID);
+        let latest: SkipBlock;
+        const latestBuf = await this.storage.get(this.dbLatest);
+        if (latestBuf !== undefined) {
+            latest = SkipBlock.decode(Buffer.from(latestBuf, "hex"));
+            Log.lvl2("Loaded latest block from db:", latest.index);
+        } else {
+            const sc = new SkipchainRPC(this.conn);
+            try {
+                latest = await sc.getSkipBlock(Buffer.from(this.id0x6000, "hex"));
+                Log.lvl2("Got skipblock 0x6000");
+            } catch (e) {
+                Log.lvl2("couldn't get block 0x6000", e);
+            }
+        }
+        this.bc = await ByzCoinRPC.fromByzcoin(this.conn, this.config.byzCoinID, 3, 1000, latest);
+        Log.lvl2("storing latest block in db:", this.bc.latest.index);
+        this.storage.set(this.dbLatest, Buffer.from(SkipBlock.encode(this.bc.latest).finish()).toString("hex"));
         logger("Done connecting", 100);
     }
 


### PR DESCRIPTION
This fixes the real problems behind #203. It also stores the latest block
locally and starts to update from that one, thus making login much
faster (~1sec instead of ~5sec).

Closes #206
Closes #208