### PR TITLE
Trust nodes

### DIFF
--- a/dynacred/src/calypso.ts
+++ b/dynacred/src/calypso.ts
@@ -54,9 +54,9 @@ export class Calypso {
         await tx.sendCoins(SpawnerTransactionBuilder.longWait);
 
         tx.progress(-40, "Getting write proof");
-        const wrProof = await this.lts.bc.getProof(wrID);
+        const wrProof = await this.lts.bc.getProof(wrID, undefined, undefined, false);
         tx.progress(-50, "Getting read proof");
-        const rdProof = await this.lts.bc.getProof(rdID);
+        const rdProof = await this.lts.bc.getProof(rdID, undefined, undefined, false);
         tx.progress(-60, "Asking for re-encryption");
         const xhatenc = await this.lts.reencryptKey(
             wrProof,

--- a/webapp/src/app/bcviewer/bcviewer.component.ts
+++ b/webapp/src/app/bcviewer/bcviewer.component.ts
@@ -208,7 +208,7 @@ class LinkInstance {
     constructor(bc: ByzCoinRPC, public inst: Instruction, public contractID: string) {
         this.instanceID = inst.instanceID;
         this.description = "loading...";
-        bc.getProofFromLatest(this.instanceID).then((p) => {
+        bc.getProofFromLatest(this.instanceID, undefined, undefined, false).then((p) => {
             this.instanceProof = p;
             switch (contractID) {
                 case "config":

--- a/webapp/src/app/byz-coin.service.ts
+++ b/webapp/src/app/byz-coin.service.ts
@@ -60,11 +60,11 @@ export class ByzCoinService extends Fetcher {
                 Log.lvl2("Got known skipblock");
             }
             this.bc = await ByzCoinRPC.fromByzcoin(this.conn, this.config.byzCoinID,
-                3, 1000, latest, this.db);
+                3, 1000, latest, this.db, false);
         } catch (e) {
             logger("Getting genesis chain", 80);
             this.bc = await ByzCoinRPC.fromByzcoin(this.conn, this.config.byzCoinID,
-                3, 1000, undefined, this.db);
+                3, 1000, undefined, this.db, false);
         }
         Log.lvl2("storing latest block in db:", this.bc.latest.index);
         await this.db.set(this.storageKeyLatest, Buffer.from(SkipBlock.encode(this.bc.latest).finish()));

--- a/webapp/src/app/explorer/explorer.component.ts
+++ b/webapp/src/app/explorer/explorer.component.ts
@@ -25,7 +25,7 @@ export class ExplorerComponent implements OnInit {
         this.route.paramMap.subscribe(async (params) => {
             const id = Buffer.from(params.get("id"), "hex");
 
-            const p = await this.bcs.bc.getProofFromLatest(id);
+            const p = await this.bcs.bc.getProofFromLatest(id, undefined, undefined, false);
             switch (p.contractID) {
 
                 case CredentialsInstance.contractID:


### PR DESCRIPTION
Forward-link verification is quite costly in javascript.
To speed up following the blockchain, the forward-links
are trusted and not verified.