### PR TITLE
Don't allow recoveries to sign

### DIFF
--- a/dynacred/spec/addressbook.spec.ts
+++ b/dynacred/spec/addressbook.spec.ts
@@ -1,5 +1,6 @@
 import { Log } from "@dedis/cothority/index";
 
+import { User } from "dynacred";
 import { BCTestEnv } from "spec/simul/itest";
 import { HistoryObs } from "spec/support/historyObs";
 
@@ -9,9 +10,10 @@ describe("Addressbook should", () => {
 
         Log.lvl1("checking credentials adding and removing");
         const user = await bct.createUser("contacts");
-        const contacts = await Promise.all(["foo", "bar", "alice"].map((alias) =>
-            bct.createUser(alias),
-        ));
+        const contacts: User[] = [];
+        for (const name of ["foo", "bar", "alice"]) {
+            contacts.push(await bct.createUser(name));
+        }
 
         Log.lvl2("subscribing to contactlist");
         const history = new HistoryObs();

--- a/dynacred/spec/support/conodes.ts
+++ b/dynacred/spec/support/conodes.ts
@@ -39,7 +39,7 @@ export async function startConodes(): Promise<void> {
     console.log("Check output.log for the logs");
     const s = fs.createWriteStream("./output.log");
 
-    docker.run("dedis/conode-test", [], s, {
+    docker.run("c4dt/conode:dev", [], s, {
         ExposedPorts: {
             "7771/tcp": {},
             "7773/tcp": {},

--- a/dynacred/src/credentialSignerBS.ts
+++ b/dynacred/src/credentialSignerBS.ts
@@ -11,6 +11,7 @@
 import { InstanceID } from "@dedis/cothority/byzcoin";
 import { Darc, IIdentity } from "@dedis/cothority/darc";
 
+import Log from "@dedis/cothority/log";
 import { DarcBS, DarcsBS } from "./byzcoin/darcsBS";
 import { CredentialInstanceMapBS } from "./credentialStructBS";
 import { SpawnerTransactionBuilder } from "./spawnerTransactionBuilder";
@@ -31,14 +32,30 @@ export class CSTypesBS extends DarcsBS {
         super(dbs);
     }
 
+    /**
+     * Creates a new entry for a device or a recovery.
+     *
+     * @param tx where to store the transactions
+     * @param name of the new device/recovery
+     * @param identity of the new device/recovery
+     */
     create(tx: SpawnerTransactionBuilder, name: string, identity: IIdentity[]): Darc {
         const newDarc = tx.spawnDarcBasic(`${this.prefix}:${name}`, identity);
-        this.link(tx, name, newDarc.getBaseID());
+        const id = newDarc.getBaseID();
+        this.link(tx, name, id);
         return newDarc;
     }
 
-    link(tx: SpawnerTransactionBuilder, name: string, id: InstanceID) {
-        this.signerDarcBS.addSignEvolve(tx, id);
+    /**
+     * Links a new darc to this device or recovery.
+     *
+     * @param tx where to store the transactions
+     * @param name of the new device/recovery
+     * @param id of the new device/recovery
+     * @param recovery if true will not create a "_sign" rule to avoid recovery-darcs with signing rights.
+     */
+    link(tx: SpawnerTransactionBuilder, name: string, id: InstanceID, recovery = false) {
+        this.signerDarcBS.addSignEvolve(tx, recovery ? undefined : id, id);
         this.cim.setEntry(tx, name, id);
     }
 

--- a/dynacred/src/index.ts
+++ b/dynacred/src/index.ts
@@ -15,6 +15,7 @@ import {
 import { Fetcher } from "./fetcher";
 import { Genesis, ICoin, IGenesisUser } from "./genesis";
 import { KeyPair } from "./keypair";
+import { Migrate } from "./migrate";
 import { SpawnerTransactionBuilder } from "./spawnerTransactionBuilder";
 import { User } from "./user";
 import { UserSkeleton } from "./userSkeleton";
@@ -47,6 +48,7 @@ export {
     IInstanceMapKV,
     ILTSIDX,
     KeyPair,
+    Migrate,
     SpawnerTransactionBuilder,
     User,
     UserSkeleton,

--- a/dynacred/src/migrate.ts
+++ b/dynacred/src/migrate.ts
@@ -1,0 +1,30 @@
+import { Darc, IdentityDarc } from "@dedis/cothority/darc";
+import { byzcoin, CredentialSignerBS } from "./index";
+import { SpawnerTransactionBuilder } from "./spawnerTransactionBuilder";
+
+/**
+ * The Migrate class puts all possible migrations into one place. For every migration, two methods
+ * should be added:
+ * - versionElement - returns a number indicating the current version
+ * - updateElement - updates to the latest available version
+ */
+export class Migrate {
+    static versionRecovery(sig: Darc, rec: byzcoin.DarcBS): number {
+        const rule = sig.rules.getRule(Darc.ruleSign);
+        const recId = new IdentityDarc({id: rec.getValue().getBaseID()}).toString();
+        if (rule.getIdentities().find((id) => id === recId)) {
+            return 0;
+        }
+        return 1;
+    }
+
+    static async updateRecovery(tx: SpawnerTransactionBuilder, sig: CredentialSignerBS, rec: byzcoin.DarcBS) {
+        if (Migrate.versionRecovery(sig.getValue(), rec) === 1) {
+            return;
+        }
+        const rules = sig.getValue().rules.clone();
+        const recId = new IdentityDarc({id: rec.getValue().getBaseID()}).toString();
+        rules.getRule(Darc.ruleSign).remove(recId);
+        sig.evolve(tx, {rules});
+    }
+}

--- a/dynacred/src/spawnerTransactionBuilder.ts
+++ b/dynacred/src/spawnerTransactionBuilder.ts
@@ -66,6 +66,7 @@ export class SpawnerTransactionBuilder extends TransactionBuilder {
                     value: Buffer.from(this.cost.toBytesLE()),
                 })]));
         }
+        Log.lvl3(this);
         const reply = await this.send([this.coin.signers], wait);
         this.cost = Long.fromNumber(0);
         return reply;

--- a/webapp/src/app/admin/devices/devices.component.html
+++ b/webapp/src/app/admin/devices/devices.component.html
@@ -18,19 +18,27 @@
 </ul>
 <h2>Recovery accounts</h2>
 <ul>
-    <li *ngFor="let device of recovery | async">
-        <div *ngIf="isActiveDevice(recovery, device)">
-            <button mat-button (click)="darcShow(device)">
-                {{ getName(recovery, device) }}
+    <li *ngFor="let recovery of recoveries | async">
+        <div *ngIf="isActiveDevice(recoveries, recovery)">
+            <button mat-button (click)="darcShow(recovery)">
+                {{ getName(recoveries, recovery) }}
             </button>
             -
-            <button mat-button (click)="recoveryDelete(device)">Delete</button>
+            <button mat-button (click)="recoveryDelete(recovery)">
+                Delete
+            </button>
             -
-            <button mat-button (click)="rename(recovery, device)">
+            <button mat-button (click)="rename(recoveries, recovery)">
                 Rename
             </button>
+            <span *ngIf="recoveryVersion0(recovery)">
+                -
+                <button mat-button (click)="recoveryUpdate(recovery)">
+                    Update Recovery
+                </button>
+            </span>
         </div>
-        <div *ngIf="!isActiveDevice(recovery, device)">
+        <div *ngIf="!isActiveDevice(recoveries, recovery)">
             Deleting
         </div>
     </li>


### PR DESCRIPTION
Previously a recovery-darc has been added to both the _sign and the evolve
rule of the signer-darc. Which meant that a recovery darc was also evaluated
for siging, which is confusing.

Even though a recovery signature can theoretically recover the ID and then
use it to sign, it should not be the default behaviour.

This PR makes it so that recovery-darcs are only added to the _evolve rule
of the signer-darc, and also adds a button to change the behaviour of
the recovery-entry in the UI.