### PR TITLE
Warn if storage cannot be used

### DIFF
--- a/webapp/src/app/app.component.ts
+++ b/webapp/src/app/app.component.ts
@@ -5,9 +5,10 @@ import { Router } from "@angular/router";
 import { IdentityWrapper } from "@dedis/cothority/darc";
 import Log from "@dedis/cothority/log";
 
-import { ByzCoinService } from "src/app/byz-coin.service";
+import { ByzCoinService, DBError } from "src/app/byz-coin.service";
 import { showDialogInfo, showDialogOKC } from "src/lib/Ui";
 import { version } from "../../package.json";
+import { DBErrorDialog } from "./db-error-dialog/db-error-dialog.component";
 
 @Component({
     selector: "app-root",
@@ -44,8 +45,12 @@ export class AppComponent implements OnInit {
                 this.logAppend(msg, perc * 0.8);
             });
         } catch (e) {
-            await showDialogInfo(this.dialog, "Error",
-                `Something went wrong while loading the config: ${e.toString()}`, "Cancel");
+            if (e instanceof DBError) {
+              await DBErrorDialog.open(this.dialog, e);
+            } else {
+              await showDialogInfo(this.dialog, "Error",
+                  `Something went wrong while loading the config: ${e.toString()}`, "Cancel");
+            }
             this.loading = false;
             return this.newUser();
         }

--- a/webapp/src/app/app.component.ts
+++ b/webapp/src/app/app.component.ts
@@ -6,7 +6,7 @@ import { IdentityWrapper } from "@dedis/cothority/darc";
 import Log from "@dedis/cothority/log";
 
 import { ByzCoinService } from "src/app/byz-coin.service";
-import { showDialogOKC } from "src/lib/Ui";
+import { showDialogInfo, showDialogOKC } from "src/lib/Ui";
 import { version } from "../../package.json";
 
 @Component({
@@ -39,9 +39,16 @@ export class AppComponent implements OnInit {
     }
 
     async ngOnInit() {
-        await this.bcs.loadConfig((msg: string, perc: number) => {
-            this.logAppend(msg, perc * 0.8);
-        });
+        try {
+            await this.bcs.loadConfig((msg: string, perc: number) => {
+                this.logAppend(msg, perc * 0.8);
+            });
+        } catch (e) {
+            await showDialogInfo(this.dialog, "Error",
+                `Something went wrong while loading the config: ${e.toString()}`, "Cancel");
+            this.loading = false;
+            return this.newUser();
+        }
 
         if (window.location.pathname.match(/\/explorer\//)) {
             Log.lvl2("using explorer - don't load user");

--- a/webapp/src/app/app.module.ts
+++ b/webapp/src/app/app.module.ts
@@ -38,6 +38,7 @@ import { C4dtComponent } from "./c4dt/c4dt.component";
 import { PartnerComponent } from "./c4dt/partner/partner.component";
 import { ProfileComponent } from "./c4dt/profile/profile.component";
 import { WelcomeComponent } from "./c4dt/welcome/welcome.component";
+import { DBErrorDialog } from "./db-error-dialog/db-error-dialog.component";
 import { CoinComponent } from "./explorer/coin/coin.component";
 import { CredentialComponent } from "./explorer/credential/credential.component";
 import { DarcComponent } from "./explorer/darc/darc.component";
@@ -65,6 +66,7 @@ import { RegisterComponent } from "./register/register.component";
         StatusComponent,
         ProfileComponent,
         AdminComponent,
+        DBErrorDialog,
         DialogOKCancelComponent,
         DialogTransactionComponent,
         BcviewerComponent,
@@ -98,6 +100,7 @@ import { RegisterComponent } from "./register/register.component";
         NewUserComponent,
         RetryLoadComponent,
         NewGroupActionComponent,
+        DBErrorDialog,
         DialogOKCancelComponent,
         DialogTransactionComponent,
         ShowBlockComponent,

--- a/webapp/src/app/byz-coin.service.ts
+++ b/webapp/src/app/byz-coin.service.ts
@@ -9,14 +9,13 @@ import Dexie from "dexie";
 import { Fetcher, User } from "dynacred";
 import { Config } from "src/lib/config";
 
-function dbError(e: Error): Error {
-    return new Error("Couldn't open storage of browser.<br>This is probably due to one" +
-        " of:<br>" +
-        "- Using private browsing mode<br>" +
-        "- Setting your browser to not remember history<br>" +
-        "For more information, go to <a" +
-        " href='https://www.c4dt.org/article/failing-omniledger-login/' target='other'>OmniLedger login problems</a>" +
-        "<br><br>System error message: " + e.toString());
+export class DBError implements Error {
+  readonly name = "DBError";
+  readonly message: string;
+
+  constructor(error: Error)  {
+    this.message = error.message;
+  }
 }
 
 @Injectable({
@@ -56,7 +55,7 @@ export class ByzCoinService extends Fetcher {
         try {
             this.db = new StorageDB();
         } catch (e) {
-            throw dbError(e);
+            throw new DBError(e);
         }
         const sc = new SkipchainRPC(this.conn);
         // @ts-ignore
@@ -85,7 +84,7 @@ export class ByzCoinService extends Fetcher {
         try {
             await this.db.set(this.storageKeyLatest, Buffer.from(SkipBlock.encode(this.bc.latest).finish()));
         } catch (e) {
-            throw dbError(e);
+            throw new DBError(e);
         }
         logger("Done connecting", 100);
     }

--- a/webapp/src/app/db-error-dialog/db-error-dialog.component.html
+++ b/webapp/src/app/db-error-dialog/db-error-dialog.component.html
@@ -1,0 +1,30 @@
+<div>
+    <h1>Error</h1>
+
+    <p>
+        Couldn't open storage of browser.<br />
+        This is probably due to one of:<br />
+        - Using private browsing mode<br />
+        - Setting your browser to not remember history<br />
+        For more information, go to
+        <a
+            href="https://www.c4dt.org/article/failing-omniledger-login/"
+            target="other"
+            >OmniLedger login problems
+        </a>
+        <br />
+        <br />
+        System error message: {{ error.message }}
+    </p>
+
+    <p>
+        <button
+            mat-raised-button
+            color="primary"
+            [mat-dialog-close]="true"
+            cdkFocusInitial
+        >
+            Cancel
+        </button>
+    </p>
+</div>

--- a/webapp/src/app/db-error-dialog/db-error-dialog.component.ts
+++ b/webapp/src/app/db-error-dialog/db-error-dialog.component.ts
@@ -1,0 +1,15 @@
+import { Component, Inject } from "@angular/core";
+import { MAT_DIALOG_DATA, MatDialog } from "@angular/material/dialog";
+import { DBError } from "../byz-coin.service";
+
+@Component({
+    templateUrl: "db-error-dialog.component.html",
+})
+export class DBErrorDialog {
+    static async open(dialog: MatDialog, error: DBError): Promise<void> {
+        const ref = dialog.open(DBErrorDialog, { data: error });
+        await new Promise((resolve) => ref.afterClosed().subscribe(resolve));
+    }
+
+    constructor(@Inject(MAT_DIALOG_DATA) readonly error: DBError) {}
+}

--- a/webapp/src/lib/dialog-okcancel.html
+++ b/webapp/src/lib/dialog-okcancel.html
@@ -1,6 +1,6 @@
 <div>
-    <h1>{{data.Title}}</h1>
-    <p [innerHTML]="data.Text"></p>
+    <h1>{{ data.Title }}</h1>
+    <p>{{ data.Text }}</p>
     <p>
         <button
             mat-raised-button
@@ -8,7 +8,7 @@
             [mat-dialog-close]="true"
             cdkFocusInitial
         >
-            {{data.Buttons.OKButton}}
+            {{ data.Buttons.OKButton }}
         </button>
         <button
             *ngIf="data.Buttons.CancelButton != ''"
@@ -17,7 +17,7 @@
             [mat-dialog-close]="false"
             cdkFocusInitial
         >
-            {{data.Buttons.CancelButton}}
+            {{ data.Buttons.CancelButton }}
         </button>
     </p>
 </div>


### PR DESCRIPTION
If the browser is in private mode or refuses to use cookies, it doesn't
allow to store data. But this feature is needed by OmniLedger login.

This PR shows an explanation in that case and points to a c4dt.org
article with more information.

closes dedis/cothority#2415