### PR TITLE
adds HTML message on 'no such service' exception when connection via CAS

### DIFF
--- a/webapp/src/app/api/v0/cas/login/login.component.html
+++ b/webapp/src/app/api/v0/cas/login/login.component.html
@@ -19,10 +19,8 @@
             >
                 Unfortunately, you don't have access :(
             </ng-container>
-            <ng-container 
-                *ngSwitchCase="StateT.NO_SUCH_SERVICE"
-            >
-            No such service : "{{service.href}}" could be found...
+            <ng-container *ngSwitchCase="StateT.NO_SUCH_SERVICE">
+                No such service : "{{ service.href }}" could be found...
             </ng-container>
             <ng-container *ngSwitchCase="StateT.ASKING_IF_LOGIN">
                 <div>

--- a/webapp/src/app/api/v0/cas/login/login.component.html
+++ b/webapp/src/app/api/v0/cas/login/login.component.html
@@ -19,6 +19,11 @@
             >
                 Unfortunately, you don't have access :(
             </ng-container>
+            <ng-container 
+                *ngSwitchCase="StateT.NO_SUCH_SERVICE"
+            >
+            No such service : "{{service.href}}" could be found...
+            </ng-container>
             <ng-container *ngSwitchCase="StateT.ASKING_IF_LOGIN">
                 <div>
                     <p>Do you want to accept or deny the request?</p>

--- a/webapp/src/app/api/v0/cas/login/login.component.ts
+++ b/webapp/src/app/api/v0/cas/login/login.component.ts
@@ -21,7 +21,7 @@ enum StateT {
     ASKING_IF_LOGIN,
     NO_ACCESS_WITH_TRANSACTION,
     REDIRECTING,
-    NO_SUCH_SERVICE
+    NO_SUCH_SERVICE,
 }
 
 @Component({

--- a/webapp/src/app/api/v0/cas/login/login.component.ts
+++ b/webapp/src/app/api/v0/cas/login/login.component.ts
@@ -21,6 +21,7 @@ enum StateT {
     ASKING_IF_LOGIN,
     NO_ACCESS_WITH_TRANSACTION,
     REDIRECTING,
+    NO_SUCH_SERVICE
 }
 
 @Component({
@@ -61,6 +62,7 @@ export class LoginComponent implements OnInit {
     async ngOnInit() {
         const action = (await this.config).serviceToAction.get(this.service.href);
         if (action === undefined) {
+            this.state = StateT.NO_SUCH_SERVICE;
             throw new Error(`no such service found: ${this.service.href}`);
         }
 
@@ -119,7 +121,8 @@ export class LoginComponent implements OnInit {
     private async putChallenge(config: Config, challenge: Buffer): Promise<boolean> {
         const action = (await this.config).serviceToAction.get(this.service.href);
         if (action === undefined) {
-            throw new Error("no such service found");
+            this.state = StateT.NO_SUCH_SERVICE;
+            throw new Error(`no such service found: ${this.service.href}`);
         }
 
         const challengeHashed = config.challengeHasher(challenge);


### PR DESCRIPTION
The StateT enum has been expanded to provide a new state that can be interpreted by Angular. I kept it very straightforward and barebones so that it behaves consistently with the way the other messages do. 