### PR TITLE
Add baseurl configuration

### DIFF
--- a/webapp/src/app/admin/contacts/contacts.component.ts
+++ b/webapp/src/app/admin/contacts/contacts.component.ts
@@ -129,8 +129,8 @@ export class ContactsComponent implements OnInit {
                     });
                 const url = this.location.prepareExternalUrl("/register?ephemeral=" +
                     newUser.keyPair.priv.marshalBinary().toString("hex"));
-                let host = window.location.host;
 
+                let host = window.location.host;
                 // Easier manual UI testing: if the url is local[1-8], return an url with the next number.
                 // This way you can have multiple users in multiple tabs on different hosts: local1, local2, ...
                 if (host.match(/^local[1-8]?:4200$/)) {
@@ -139,9 +139,11 @@ export class ContactsComponent implements OnInit {
                         index = 0;
                     }
                     host = "local" + (index + 1) + ":4200";
+                } else {
+                    host = this.builder.config.baseURL;
                 }
                 this.dialog.open(SignupLinkComponent, {
-                    data: `${window.location.protocol}//${host + url}`,
+                    data: `${host + url}`,
                     width: "400px",
                 });
             }
@@ -216,7 +218,7 @@ export class ContactsComponent implements OnInit {
                         ephemeralIdentity.secret.marshalBinary().toString("hex"));
                 });
         if (deviceStr) {
-            const url = window.location.protocol + "//" + window.location.host +
+            const url = this.builder.config.baseURL +
                 this.location.prepareExternalUrl(deviceStr);
             this.dialog.open(ShowComponent, {data: url});
         }

--- a/webapp/src/app/admin/devices/devices.component.ts
+++ b/webapp/src/app/admin/devices/devices.component.ts
@@ -86,7 +86,7 @@ export class DevicesComponent {
                             }, 10);
                             return this.user.getUrlForDevice(ephemeralIdentity.secret);
                         });
-                const url = window.location.protocol + "//" + window.location.host +
+                const url = this.builder.config.baseURL +
                     this.location.prepareExternalUrl(device);
                 this.dialog.open(ShowComponent, {data: url});
             }

--- a/webapp/src/app/newuser/newuser.component.html
+++ b/webapp/src/app/newuser/newuser.component.html
@@ -10,5 +10,12 @@
                 >Showcase</a
             >
         </p>
+        <p>
+            If you do have a login but it doesn't work, it might be that it's
+            still stored in the old location at demo.c4dt.org. You can recover
+            it by going to the following link, and by adding a device. Clicking
+            on it, it will install your login under the new URL.
+            <a href="https://demo.c4dt.org/omniledger">Old Login</a>
+        </p>
     </div>
 </div>

--- a/webapp/src/lib/config.ts
+++ b/webapp/src/lib/config.ts
@@ -33,11 +33,19 @@ export class Config {
             return Buffer.from(field, "hex");
         };
 
+        const asString = (field: any): string => {
+            if (typeof field !== "string") {
+                throw Error("is not a string");
+            }
+            return field;
+        };
+
         return new Config(
             getField("ByzCoinID", asID),
             Roster.fromTOML(raw),
             tryToGetField("AdminDarcID", asID),
             tryToGetField("Ephemeral", asID),
+            tryToGetField("BaseURL", asString),
         );
     }
 
@@ -48,5 +56,10 @@ export class Config {
         // initial deploy; that's also why it's optional
         readonly adminDarcID?: ID,
         readonly ephemeral?: ID,
-    ) {}
+        readonly baseURL?: string,
+    ) {
+        if (baseURL === undefined) {
+            this.baseURL = window.location.protocol + "//" + window.location.host;
+        }
+    }
 }


### PR DESCRIPTION
Now that there will be two installations - one on demo.c4dt.org to recover the accounts,
and one on login.c4dt.org - there needs to be a way to force the creation of the links
to the new installation.

This PR adds a field 'BaseURL' to the config.toml that will be used to create the links for
new users and recovery accounts.