### PR TITLE
webapp/cas-test: disable GPU

### DIFF
--- a/webapp/cas/cmd/cas-test/main.go
+++ b/webapp/cas/cmd/cas-test/main.go
@@ -52,7 +52,7 @@ func runClicker(c *cli.Context, clicker func(string, *agouti.Page) error) (err e
 	}
 	url := c.Args().First()
 
-	driver := agouti.ChromeDriver(agouti.ChromeOptions("args", []string{"headless"}))
+	driver := agouti.ChromeDriver(agouti.ChromeOptions("args", []string{"headless", "disable-gpu"}))
 	if err := driver.Start(); err != nil {
 		return fmt.Errorf("driver start: %v", err)
 	}


### PR DESCRIPTION
Chrome is unstable and might fail on headless systems. Disabling GPU rendering which seems more reliable.

The root cause of why the stats suddenly failed is still unknown. We might never know. Life has such mysteries.