### PR TITLE
Deploy on main

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,6 @@ dist: trusty
 addons:
   ssh_known_hosts: c4dtsrv1.epfl.ch
 
-stages:
-  - build
-  - name: deploy
-    if: branch = main
-
 jobs:
   include:
 
@@ -76,6 +71,9 @@ jobs:
       deploy:
         provider: script
         script: ssh omniledger@c4dtsrv1.epfl.ch bin/update.sh
+      on:
+        branch:
+          main
 
     - name: NPM
       language: node_js


### PR DESCRIPTION
The change from master to main showed that travis by default runs
the deploy stage only on master.
This PR fixes this to run the deploy script on the main branch.