### PR TITLE
Correctly recover user

### DIFF
--- a/dynacred/src/credentialSignerBS.ts
+++ b/dynacred/src/credentialSignerBS.ts
@@ -11,10 +11,10 @@
 import { InstanceID } from "@dedis/cothority/byzcoin";
 import { Darc, IIdentity } from "@dedis/cothority/darc";
 
-import Log from "@dedis/cothority/log";
-import { DarcBS, DarcsBS } from "./byzcoin/darcsBS";
+import { DarcBS, DarcsBS } from "./byzcoin";
 import { CredentialInstanceMapBS } from "./credentialStructBS";
 import { SpawnerTransactionBuilder } from "./spawnerTransactionBuilder";
+import { TransactionBuilder } from "./byzcoin";
 
 export class CredentialSignerBS extends DarcBS {
     constructor(darcBS: DarcBS,
@@ -25,7 +25,7 @@ export class CredentialSignerBS extends DarcBS {
 }
 
 export class CSTypesBS extends DarcsBS {
-    constructor(private signerDarcBS: DarcBS,
+    constructor(readonly signerDarcBS: DarcBS,
                 readonly cim: CredentialInstanceMapBS,
                 readonly prefix: string,
                 dbs: DarcsBS) {
@@ -54,7 +54,7 @@ export class CSTypesBS extends DarcsBS {
      * @param id of the new device/recovery
      * @param recovery if true will not create a "_sign" rule to avoid recovery-darcs with signing rights.
      */
-    link(tx: SpawnerTransactionBuilder, name: string, id: InstanceID, recovery = false) {
+    link(tx: TransactionBuilder, name: string, id: InstanceID, recovery = false) {
         this.signerDarcBS.addSignEvolve(tx, recovery ? undefined : id, id);
         this.cim.setEntry(tx, name, id);
     }

--- a/dynacred/src/credentialStructBS.ts
+++ b/dynacred/src/credentialStructBS.ts
@@ -8,8 +8,8 @@ import { Attribute, Credential, CredentialsInstance, CredentialStruct } from "@d
 import { Point, PointFactory } from "@dedis/kyber";
 
 import { ConvertBS } from "./observableUtils";
-import { SpawnerTransactionBuilder } from "./spawnerTransactionBuilder";
 import { bufferToObject } from "./utils";
+import { TransactionBuilder } from "./byzcoin";
 
 /**
  * The CredentialStructBS is the main part of a user-account in ByzCoin.
@@ -61,7 +61,7 @@ export class CredentialStructBS extends BehaviorSubject<CredentialStruct> {
      * @param tx
      * @param cred
      */
-    updateCredential(tx: SpawnerTransactionBuilder, ...cred: IUpdateCredential[]) {
+    updateCredential(tx: TransactionBuilder, ...cred: IUpdateCredential[]) {
         const orig = this.getValue();
         for (const c of cred) {
             if (c.value !== undefined) {
@@ -74,13 +74,13 @@ export class CredentialStructBS extends BehaviorSubject<CredentialStruct> {
         this.setCredentialStruct(tx, orig);
     }
 
-    setCredential(tx: SpawnerTransactionBuilder, cred: Credential) {
+    setCredential(tx: TransactionBuilder, cred: Credential) {
         const credStruct = this.getValue();
         credStruct.setCredential(cred.name, cred);
         this.setCredentialStruct(tx, credStruct);
     }
 
-    setCredentialStruct(tx: SpawnerTransactionBuilder, credStruct: CredentialStruct) {
+    setCredentialStruct(tx: TransactionBuilder, credStruct: CredentialStruct) {
         const versionBuf = Buffer.alloc(4);
         versionBuf.writeInt32LE(this.credPublic.version.getValue() + 1, 0);
         credStruct.setAttribute(ECredentials.pub, EAttributesPublic.version, versionBuf);
@@ -161,15 +161,15 @@ export class CredentialBS extends BehaviorSubject<Credential> {
         return new AttributeInstanceSetBS(this, bs, name);
     }
 
-    setValue(tx: SpawnerTransactionBuilder, attr: string, value: string | Buffer) {
+    setValue(tx: TransactionBuilder, attr: string, value: string | Buffer) {
         this.csbs.updateCredential(tx, {cred: this.cred, attr, value});
     }
 
-    rmValue(tx: SpawnerTransactionBuilder, attr: string) {
+    rmValue(tx: TransactionBuilder, attr: string) {
         this.setValue(tx, attr, undefined);
     }
 
-    set(tx: SpawnerTransactionBuilder, cred: Credential) {
+    set(tx: TransactionBuilder, cred: Credential) {
         this.csbs.setCredential(tx, cred);
     }
 
@@ -198,7 +198,7 @@ export class CredentialInstanceMapBS extends BehaviorSubject<InstanceMap> {
         bsim.subscribe(this);
     }
 
-    setInstanceMap(tx: SpawnerTransactionBuilder, val: InstanceMap) {
+    setInstanceMap(tx: TransactionBuilder, val: InstanceMap) {
         const cred = this.cbs.getValue();
         cred.attributes.splice(0);
         Array.from(val.map.entries()).forEach(([idStr, name]) =>
@@ -206,13 +206,13 @@ export class CredentialInstanceMapBS extends BehaviorSubject<InstanceMap> {
         this.cbs.set(tx, cred);
     }
 
-    setEntry(tx: SpawnerTransactionBuilder, name: string, id: Buffer) {
+    setEntry(tx: TransactionBuilder, name: string, id: Buffer) {
         const val = this.getValue();
         val.map.set(id.toString("hex"), name);
         return this.setInstanceMap(tx, val);
     }
 
-    rmEntry(tx: SpawnerTransactionBuilder, id: Buffer) {
+    rmEntry(tx: TransactionBuilder, id: Buffer) {
         const val = this.getValue();
         val.map.delete(id.toString("hex"));
         this.setInstanceMap(tx, val);
@@ -234,7 +234,7 @@ export class AttributeBufferBS extends BehaviorSubject<Buffer> {
         bsb.subscribe(this);
     }
 
-    setValue(tx: SpawnerTransactionBuilder, val: Buffer) {
+    setValue(tx: TransactionBuilder, val: Buffer) {
         return this.cbs.setValue(tx, this.name, val);
     }
 }
@@ -246,7 +246,7 @@ export class AttributeStringBS extends BehaviorSubject<string> {
         bss.subscribe(this);
     }
 
-    setValue(tx: SpawnerTransactionBuilder, val: string) {
+    setValue(tx: TransactionBuilder, val: string) {
         return this.cbs.setValue(tx, this.name, val);
     }
 }
@@ -258,7 +258,7 @@ export class AttributeLongBS extends BehaviorSubject<Long> {
         bss.subscribe(this);
     }
 
-    setValue(tx: SpawnerTransactionBuilder, val: Long) {
+    setValue(tx: TransactionBuilder, val: Long) {
         return this.cbs.setValue(tx, this.name, Buffer.from(val.toBytesLE()));
     }
 }
@@ -270,7 +270,7 @@ export class AttributePointBS extends BehaviorSubject<Point | undefined> {
         bss.subscribe(this);
     }
 
-    setValue(tx: SpawnerTransactionBuilder, val: Point) {
+    setValue(tx: TransactionBuilder, val: Point) {
         return this.cbs.setValue(tx, this.name, val.toProto());
     }
 }
@@ -282,7 +282,7 @@ export class AttributeBoolBS extends BehaviorSubject<boolean> {
         bss.subscribe(this);
     }
 
-    setValue(tx: SpawnerTransactionBuilder, val: boolean) {
+    setValue(tx: TransactionBuilder, val: boolean) {
         return this.cbs.setValue(tx, this.name, Buffer.from(val ? "true" : "false"));
     }
 }
@@ -294,7 +294,7 @@ export class AttributeNumberBS extends BehaviorSubject<number> {
         bss.subscribe(this);
     }
 
-    setValue(tx: SpawnerTransactionBuilder, val: number) {
+    setValue(tx: TransactionBuilder, val: number) {
         const buf = Buffer.alloc(4);
         buf.writeInt32LE(val, 0);
         return this.cbs.setValue(tx, this.name, buf);
@@ -308,7 +308,7 @@ export class AttributeInstanceSetBS extends BehaviorSubject<InstanceSet> {
         bsis.subscribe(this);
     }
 
-    setInstanceSet(tx: SpawnerTransactionBuilder, val: InstanceSet) {
+    setInstanceSet(tx: TransactionBuilder, val: InstanceSet) {
         this.cbs.setValue(tx, this.name, val.toBuffer());
     }
 }

--- a/dynacred/src/user.ts
+++ b/dynacred/src/user.ts
@@ -133,13 +133,14 @@ export class User {
         return new SpawnerTransactionBuilder(this.bc, this.spawnerInstanceBS.getValue(), this.iCoin());
     }
 
-    async executeTransactions(addTxs: (tx: SpawnerTransactionBuilder) => Promise<unknown> | unknown,
-                              wait = 0): Promise<void> {
+    async executeTransactions<T>(addTxs: (tx: SpawnerTransactionBuilder) => Promise<T> | T,
+                              wait = 0): Promise<T> {
         const tx = new SpawnerTransactionBuilder(this.bc, this.spawnerInstanceBS.getValue(), this.iCoin());
-        await addTxs(tx);
+        const ret = await addTxs(tx);
         if (tx.hasInstructions()) {
             await tx.sendCoins(wait);
         }
+        return ret;
     }
 }
 

--- a/dynacred/src/userSkeleton.ts
+++ b/dynacred/src/userSkeleton.ts
@@ -110,7 +110,6 @@ export class UserSkeleton {
 
     addRecovery(name: string, id: InstanceID) {
         const idDarc = new IdentityDarc({id}).toString();
-        this.darcSign.rules.getRule(Darc.ruleSign).append(idDarc, Rule.OR);
         this.darcSign.rules.getRule(DarcInstance.ruleEvolve).append(idDarc, Rule.OR);
         this.cred.setAttribute(ECredentials.recoveries, name, id);
         this.updateDarcs();

--- a/webapp/src/app/admin/contacts/contacts.component.ts
+++ b/webapp/src/app/admin/contacts/contacts.component.ts
@@ -210,11 +210,11 @@ export class ContactsComponent implements OnInit {
                         this.user.credStructBS.credPublic.alias.getValue(),
                         now.getFullYear(), now.getMonth() + 1, now.getDate(), now.getHours(), now.getMinutes());
                     const ephemeralIdentity = SignerEd25519.random();
-                    let newDarc: Darc;
-                    await this.user.executeTransactions((tx) => {
-                        newDarc = tx.spawnDarcBasic(`recover:${name}`, [ephemeralIdentity]);
+                    const newDarc = await this.user.executeTransactions((tx) => {
+                        const d = tx.spawnDarcBasic(`recover:${name}`, [ephemeralIdentity]);
                         const idEph = newDarc.getBaseID();
                         cSign.devices.signerDarcBS.addSignEvolve(tx, idEph, idEph);
+                        return d;
                     }, 10);
 
                     progress(75, "Attaching new device to user");

--- a/webapp/src/app/admin/contacts/contacts.component.ts
+++ b/webapp/src/app/admin/contacts/contacts.component.ts
@@ -7,7 +7,7 @@ import Long from "long";
 import { sprintf } from "sprintf-js";
 
 import DarcInstance from "@dedis/cothority/byzcoin/contracts/darc-instance";
-import { IdentityWrapper, SignerEd25519 } from "@dedis/cothority/darc";
+import { Darc, IdentityWrapper, SignerEd25519 } from "@dedis/cothority/darc";
 import Log from "@dedis/cothority/log";
 
 import {
@@ -204,15 +204,23 @@ export class ContactsComponent implements OnInit {
                         throw new Error("cannot recover this user");
                     }
 
-                    progress(70, "Creating new device for recovery");
+                    progress(50, "Creating new device for recovery");
                     const now = new Date();
                     const name = sprintf("recovered by %s at %d/%02d/%02d %02d:%02d",
                         this.user.credStructBS.credPublic.alias.getValue(),
                         now.getFullYear(), now.getMonth() + 1, now.getDate(), now.getHours(), now.getMinutes());
                     const ephemeralIdentity = SignerEd25519.random();
+                    let newDarc: Darc;
                     await this.user.executeTransactions((tx) => {
-                        cSign.devices.create(tx, name, [ephemeralIdentity]);
+                        newDarc = tx.spawnDarcBasic(`recover:${name}`, [ephemeralIdentity]);
+                        const idEph = newDarc.getBaseID();
+                        cSign.devices.signerDarcBS.addSignEvolve(tx, idEph, idEph);
                     }, 10);
+
+                    progress(75, "Attaching new device to user");
+                    const txDevice = new byzcoin.TransactionBuilder(this.user.bc);
+                    cSign.devices.cim.setEntry(txDevice, name, newDarc.getBaseID());
+                    await txDevice.send([[ephemeralIdentity]], 10);
                     return sprintf("%s?credentialIID=%s&ephemeral=%s", User.urlNewDevice,
                         c.id.toString("hex"),
                         ephemeralIdentity.secret.marshalBinary().toString("hex"));


### PR DESCRIPTION
Currently when recovering a user, it tries to:
1. update the signer-darc of the user
2. insert the device in the list of the user

But as of #263, recoveries are only allowed to evolve the user-signer-darc,
but not to sign on its behalf. So the two steps need to be signed by
different signers:
1. can be signed by the user that does the recovery
2. must be signed by the new ephemeral key