### PR TITLE
Darc identity tsm

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -58,6 +58,9 @@ jobs:
             run:
                 working-directory: webapp
         steps:
+            - uses: actions/setup-node@v3
+              with:
+                 node-version: '16'
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v2
 
@@ -80,7 +83,7 @@ jobs:
             - uses: Jerome1337/gofmt-action@v1.0.4
             - run: go vet ./...
 
-            - uses: dominikh/staticcheck-action@v1.1.0
+            - uses: dominikh/staticcheck-action@v1.3.0
             - uses: Jerome1337/golint-action@v1.0.2
 
     build-cas:

--- a/dynacred/spec/signers.spec.ts
+++ b/dynacred/spec/signers.spec.ts
@@ -1,6 +1,6 @@
 import { filter, first } from "rxjs/operators";
 
-import {Darc, IdentityDarc, SignerEd25519} from "@dedis/cothority/darc";
+import { Darc, IdentityDarc, SignerEd25519 } from "@dedis/cothority/darc";
 import Log from "@dedis/cothority/log";
 
 import { KeyPair } from "src/keypair";

--- a/dynacred/spec/simul/byzcoinSimul.ts
+++ b/dynacred/spec/simul/byzcoinSimul.ts
@@ -260,7 +260,7 @@ export class ByzCoinSimul {
           this.db.set(idStr, Buffer.from(JSON.stringify(proof.inst)))),
         // Debug output
         tap((proof) =>
-            Log.lvl3(`Updating proof of ${proof.contractID} / ${proof.version} / ${proof.key.toString('hex')}`))
+            Log.lvl3(`Updating proof of ${proof.contractID} / ${proof.version} / ${proof.key.toString("hex")}`)),
         // Link to the BehaviorSubject
       ).subscribe(bsNew);
 

--- a/dynacred/src/byzcoin/transactionBuilder.ts
+++ b/dynacred/src/byzcoin/transactionBuilder.ts
@@ -39,7 +39,7 @@ export class TransactionBuilder {
     /**
      * Returns the ClientTransaction for the instructions stored.
      */
-    clientTransaction(): ClientTransaction{
+    clientTransaction(): ClientTransaction {
         const ctx = ClientTransaction.make(this.bc.getProtocolVersion(), ...this.instructions);
         this.instructions = [];
         return ctx;

--- a/dynacred/src/byzcoin/transactionBuilder.ts
+++ b/dynacred/src/byzcoin/transactionBuilder.ts
@@ -37,6 +37,13 @@ export class TransactionBuilder {
     }
 
     /**
+     * Returns the ClientTransaction for the instructions stored.
+     */
+    clientTransaction(): ClientTransaction{
+        return ClientTransaction.make(this.bc.getProtocolVersion(), ...this.instructions);
+    }
+
+    /**
      * @return true if one or more instructions are available.
      */
     hasInstructions(): boolean {

--- a/dynacred/src/byzcoin/transactionBuilder.ts
+++ b/dynacred/src/byzcoin/transactionBuilder.ts
@@ -40,7 +40,9 @@ export class TransactionBuilder {
      * Returns the ClientTransaction for the instructions stored.
      */
     clientTransaction(): ClientTransaction{
-        return ClientTransaction.make(this.bc.getProtocolVersion(), ...this.instructions);
+        const ctx = ClientTransaction.make(this.bc.getProtocolVersion(), ...this.instructions);
+        this.instructions = [];
+        return ctx;
     }
 
     /**

--- a/dynacred/src/credentialSignerBS.ts
+++ b/dynacred/src/credentialSignerBS.ts
@@ -12,9 +12,9 @@ import { InstanceID } from "@dedis/cothority/byzcoin";
 import { Darc, IIdentity } from "@dedis/cothority/darc";
 
 import { DarcBS, DarcsBS } from "./byzcoin";
+import { TransactionBuilder } from "./byzcoin";
 import { CredentialInstanceMapBS } from "./credentialStructBS";
 import { SpawnerTransactionBuilder } from "./spawnerTransactionBuilder";
-import { TransactionBuilder } from "./byzcoin";
 
 export class CredentialSignerBS extends DarcBS {
     constructor(darcBS: DarcBS,

--- a/dynacred/src/credentialStructBS.ts
+++ b/dynacred/src/credentialStructBS.ts
@@ -7,9 +7,9 @@ import { Argument, InstanceID } from "@dedis/cothority/byzcoin";
 import { Attribute, Credential, CredentialsInstance, CredentialStruct } from "@dedis/cothority/byzcoin/contracts";
 import { Point, PointFactory } from "@dedis/kyber";
 
+import { TransactionBuilder } from "./byzcoin";
 import { ConvertBS } from "./observableUtils";
 import { bufferToObject } from "./utils";
-import { TransactionBuilder } from "./byzcoin";
 
 /**
  * The CredentialStructBS is the main part of a user-account in ByzCoin.

--- a/dynacred/src/spawnerTransactionBuilder.ts
+++ b/dynacred/src/spawnerTransactionBuilder.ts
@@ -51,13 +51,12 @@ export class SpawnerTransactionBuilder extends TransactionBuilder {
     }
 
     async sendCoins(wait = 0, signers = [this.coin.signers]): Promise<[ClientTransaction, AddTxResponse]> {
-        this.addCoins(wait, signers);
+        this.addCoins();
         const reply = await this.send(signers, wait);
-        this.cost = Long.fromNumber(0);
         return reply;
     }
 
-    addCoins(wait = 0, signers = [this.coin.signers]) {
+    addCoins() {
         if (!this.hasInstructions()) {
             throw new Error("no instructions to send");
         }
@@ -73,6 +72,7 @@ export class SpawnerTransactionBuilder extends TransactionBuilder {
                     value: Buffer.from(this.cost.toBytesLE()),
                 })]));
         }
+        this.cost = Long.fromNumber(0);
         Log.lvl3(this);
     }
 
@@ -162,9 +162,5 @@ export class SpawnerTransactionBuilder extends TransactionBuilder {
 
         Log.lvl3("Spawning credential with darcID", user.darcCred.getBaseID());
         this.spawnCredential(user.cred, user.darcCred.getBaseID());
-    }
-
-    clientInstructions(): ClientTransaction {
-        return super.clientTransaction()
     }
 }

--- a/dynacred/src/spawnerTransactionBuilder.ts
+++ b/dynacred/src/spawnerTransactionBuilder.ts
@@ -1,7 +1,7 @@
 import Long from "long";
 
-import {Log} from "@dedis/cothority";
-import {Argument, ByzCoinRPC, ClientTransaction, Instance, InstanceID, Instruction} from "@dedis/cothority/byzcoin";
+import { Log } from "@dedis/cothority";
+import { Argument, ByzCoinRPC, ClientTransaction, Instance, InstanceID, Instruction } from "@dedis/cothority/byzcoin";
 import {
     Coin,
     CoinInstance,
@@ -11,17 +11,17 @@ import {
     SPAWNER_COIN,
     SpawnerInstance,
 } from "@dedis/cothority/byzcoin/contracts";
-import {AddTxResponse} from "@dedis/cothority/byzcoin/proto/requests";
-import {Darc, IIdentity, Rule} from "@dedis/cothority/darc";
+import { AddTxResponse } from "@dedis/cothority/byzcoin/proto/requests";
+import { Darc, IIdentity, Rule } from "@dedis/cothority/darc";
 
 import ValueInstance from "@dedis/cothority/byzcoin/contracts/value-instance";
-import {CalypsoReadInstance, CalypsoWriteInstance, Read, Write} from "@dedis/cothority/calypso";
-import {Point} from "@dedis/kyber";
-import {randomBytes} from "crypto-browserify";
-import {TransactionBuilder} from "./byzcoin";
-import {EAttributesPublic, ECredentials} from "./credentialStructBS";
-import {ICoin} from "./genesis";
-import {UserSkeleton} from "./userSkeleton";
+import { CalypsoReadInstance, CalypsoWriteInstance, Read, Write } from "@dedis/cothority/calypso";
+import { Point } from "@dedis/kyber";
+import { randomBytes } from "crypto-browserify";
+import { TransactionBuilder } from "./byzcoin";
+import { EAttributesPublic, ECredentials } from "./credentialStructBS";
+import { ICoin } from "./genesis";
+import { UserSkeleton } from "./userSkeleton";
 
 export type TProgress = (percentage: number, text: string) => void;
 
@@ -73,7 +73,6 @@ export class SpawnerTransactionBuilder extends TransactionBuilder {
                 })]));
         }
         this.cost = Long.fromNumber(0);
-        Log.lvl3(this);
     }
 
     spawnDarc(d: Darc): Darc {

--- a/dynacred/src/user.ts
+++ b/dynacred/src/user.ts
@@ -134,7 +134,7 @@ export class User {
     }
 
     async executeTransactions<T>(addTxs: (tx: SpawnerTransactionBuilder) => Promise<T> | T,
-                              wait = 0): Promise<T> {
+                                 wait = 0): Promise<T> {
         const tx = new SpawnerTransactionBuilder(this.bc, this.spawnerInstanceBS.getValue(), this.iCoin());
         const ret = await addTxs(tx);
         if (tx.hasInstructions()) {

--- a/tsconfig.common.json
+++ b/tsconfig.common.json
@@ -4,40 +4,29 @@
       "dynacred": [
         "../dynacred/src",
       ],
-      "@c4dt/cothority/*": [
-        "../cothority/external/js/cothority/src/*",
-        "src/lib/cothority/*",
-        "node_modules/@c4dt/cothority/*"
-      ],
       "@dedis/cothority": [
         "../cothority/external/js/cothority/src",
-        "src/lib/cothority/*",
-        "node_modules/@dedis/cothority/*"
+        "src/lib/cothority",
+        "node_modules/@dedis/cothority/dist",
+        "node_modules/@dedis/cothority"
       ],
       "@dedis/cothority/*": [
         "../cothority/external/js/cothority/src/*",
         "src/lib/cothority/*",
+        "node_modules/@dedis/cothority/dist/*",
         "node_modules/@dedis/cothority/*"
       ],
       "@dedis/kyber": [
         "../cothority/external/js/kyber/src",
         "src/lib/kyber",
+        "node_modules/@dedis/kyber/dist",
         "node_modules/@dedis/kyber"
       ],
       "@dedis/kyber/*": [
         "../cothority/external/js/kyber/src/*",
         "src/lib/kyber/*",
+        "node_modules/@dedis/kyber/dist/*",
         "node_modules/@dedis/kyber/*"
-      ],
-      "@c4dt/kyber": [
-        "../cothority/external/js/kyber/src",
-        "src/lib/kyber",
-        "node_modules/@c4dt/kyber"
-      ],
-      "@c4dt/kyber/*": [
-        "../cothority/external/js/kyber/src/*",
-        "src/lib/kyber/*",
-        "node_modules/@c4dt/kyber/*"
       ],
     }
   }


### PR DESCRIPTION
Makes the `Calypso` and `TransactionBuilder` a bit more fine-grained so that the TSM signatures can also be used. The main difference with the other signatures is that TSM signatures are asynchronous.

Also includes some fixes to make it possible to use `npm link @deds/cothority` and `npm link @dedis/kyber` without hell breaking loose.