### PR TITLE
Use new names

### DIFF
--- a/webapp/src/assets/config.dedis.toml
+++ b/webapp/src/assets/config.dedis.toml
@@ -5,7 +5,7 @@ SignupNode = "https://byzcoin-signup.c4dt.org"
   Address = "tls://conode.c4dt.org:7770"
   Suite = "Ed25519"
   Public = "67e30e168f83c4d4614e277cefba42dbc1fb5886b3945364ea5dae3f4e4fbc0d"
-  Description = "C4DT Conode"
+  Description = "C4DT Conode 1"
   URL = "https://conode.c4dt.org"
   [servers.Services]
     [servers.Services.ByzCoin]
@@ -19,7 +19,7 @@ SignupNode = "https://byzcoin-signup.c4dt.org"
   Address = "tls://conode2.c4dt.org:7771"
   Suite = "Ed25519"
   Public = "8592a0dc194d1ba035693d922dd1e5076c89c28275143de80ea4e9640b4df6ea"
-  Description = "2nd c4dt conode"
+  Description = "C4DT Conode 2"
   URL = "https://conode2.c4dt.org"
   [servers.Services]
     [servers.Services.ByzCoin]


### PR DESCRIPTION
The ansible-config defines the names of the conode.c4dt.org and conode2.c4dt.org differently.